### PR TITLE
Fix - API - The API now returns correct page and count values when the search filter includes Last Verified, Last Updated, or Created date

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -31,6 +31,7 @@
     "route_static":"/static",
 
     "route_suggestions":"/suggestions",
+    "route_suggestions_count":"/suggestions/count",
 
     "route_users":"/users",
     "route_users_count":"/users/count",

--- a/src/routes/entity.js
+++ b/src/routes/entity.js
@@ -1,6 +1,6 @@
 import {Comment, Rating, Suggestion} from '../mongoose';
 import {handleBadRequest, handleErr, handleNotFound} from '../utils';
-import {getEntityQuery} from '../utils/query';
+import {getEntityQuery, ITEM_PAGE_LIMIT} from '../utils/query';
 
 export const getComments = async (req, res) => {
 	const {orgId, serviceId} = req?.params;
@@ -155,6 +155,16 @@ export const getSuggestions = async (req, res) => {
 	await Suggestion.find({})
 		.then((suggestions) => {
 			return res.json(suggestions);
+		})
+		.catch((err) => handleErr(err, res));
+};
+
+export const getSuggestionsCount = async (req, res) => {
+	await Suggestion.find({})
+		.then((suggestions) => {
+			const pages = Math.ceil(suggestions.length / ITEM_PAGE_LIMIT);
+
+			return res.json({count: suggestions.length, pages});
 		})
 		.catch((err) => handleErr(err, res));
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -9,6 +9,7 @@ import {
 	getRatings,
 	deleteRatingById,
 	getSuggestions,
+	getSuggestionsCount,
 	getUserSuggestionsByEmail,
 	updateComments,
 	deleteCommentById,
@@ -187,6 +188,7 @@ versionOneRouter.patch(
 
 // Suggestions - Automated Tested
 versionOneRouter.get('/suggestions', getSuggestions);
+versionOneRouter.get('/suggestions/count', getSuggestionsCount);
 versionOneRouter.post('/suggestions', createSuggestions);
 versionOneRouter.delete('/suggestions/:suggestionId', deleteSuggestion);
 versionOneRouter.get('/suggestions/:email', getUserSuggestionsByEmail);

--- a/src/routes/organizations.js
+++ b/src/routes/organizations.js
@@ -19,6 +19,7 @@ const ObjectId = mongoose.Types.ObjectId;
 export const getOrgs = async (req, res) => {
 	const {limit, offset} = parsePageQuery(req?.query?.page);
 	const {query} = req;
+
 	let dbQuery = getOrganizationQuery(query);
 	var obj = {};
 
@@ -114,9 +115,55 @@ export const getOrgsByName = async (req, res) => {
 };
 
 export const getOrgsCount = async (req, res) => {
-	const query = getOrganizationQuery(req?.query);
+	const {query} = req;
+	let dbQuery = getOrganizationQuery(query);
 
-	await Organization.countDocuments(query)
+	if (query.lastVerified) {
+		dbQuery = Object.assign(dbQuery, {
+			verified_at: {$lte: new Date(query.lastVerified)}
+		});
+	}
+
+	if (query.lastVerifiedStart) {
+		dbQuery = Object.assign(dbQuery, {
+			verified_at: {
+				$gte: new Date(query.lastVerifiedStart),
+				$lte: new Date(query.lastVerifiedEnd)
+			}
+		});
+	}
+
+	if (query.lastUpdated) {
+		dbQuery = Object.assign(dbQuery, {
+			updated_at: {$lte: new Date(query.lastUpdated)}
+		});
+	}
+
+	if (query.lastUpdatedStart) {
+		dbQuery = Object.assign(dbQuery, {
+			updated_at: {
+				$gte: new Date(query.lastUpdatedStart),
+				$lte: new Date(query.lastUpdatedEnd)
+			}
+		});
+	}
+
+	if (query.createdAt) {
+		dbQuery = Object.assign(dbQuery, {
+			created_at: {$lte: new Date(query.createdAt)}
+		});
+	}
+
+	if (query.createdAtStart) {
+		dbQuery = Object.assign(dbQuery, {
+			created_at: {
+				$gte: new Date(query.createdAtStart),
+				$lte: new Date(query.createdAtEnd)
+			}
+		});
+	}
+
+	await Organization.countDocuments(dbQuery)
 		.then((count) => {
 			const pages = Math.ceil(count / ITEM_PAGE_LIMIT);
 

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -1118,6 +1118,33 @@
         }
       }
     },
+    "/suggestions/count": {
+      "get": {
+        "summary": "Get count of the suggestions query. Uses the same parameters as GET /suggestions",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "count": {
+                      "type": "integer",
+                      "example": 100
+                    },
+                    "pages": {
+                      "type": "integer",
+                      "example": 5
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/users": {
       "get": {
         "summary": "Get users",


### PR DESCRIPTION
This PR should be merged with it's associated PR on control panel - https://github.com/asylum-connect/control-panel/pull/134

## Description

1. The count value was not correct after searching based on Last Verified, Last Updated, or Created date  - the correct organizations are returned but the count shows the max number of organizations (provided no other search terms were used)
* updated the getOrgsCount function to include the date parameters in the query

2. The Admin Suggestions page did not have pagination for the Pending Affiliates section and the Suggestions section in control panel
* added an endpoint to get suggestions/count so we can have proper pagination for those two sections

## Asana ticket:
https://app.asana.com/0/1132189118126148/1202515609917986

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @trigal2012 **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test

<!-- Provide instructions for how to test/validate the changes. -->
